### PR TITLE
Add notification settings link in settings screen

### DIFF
--- a/Source/Controllers/Settings.swift
+++ b/Source/Controllers/Settings.swift
@@ -17,11 +17,20 @@ class SettingsViewController: ViewController {
     private lazy var cells = [
         [
             Cell(
+                identifier: .regular,
+                action: openNotificationSettings,
+                configure: {
+                    $0.textLabel?.text = "Notifications"
+                    $0.textLabel?.textColor = .textColor
+                }
+            ),
+            Cell(
                 identifier: .detail,
                 action: nil,
                 configure: {
                     $0.textLabel?.text = "Version"
-                    $0.textLabel?.textColor = .textColor
+                    $0.textLabel?.textColor = .mutedTextColor
+                    $0.detailTextLabel?.textColor = .mutedTextColor
                     $0.isUserInteractionEnabled = false
 
                     let info = Bundle.main.infoDictionary
@@ -68,6 +77,10 @@ class SettingsViewController: ViewController {
         self.letterLabel.text = String(describing: account.letter)
 
         self.avatarView.draw(with: account.colors)
+    }
+
+    private func openNotificationSettings() {
+        UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!)
     }
 
     private func logOut() {

--- a/Source/Utils/Extensions/UIColor+Constants.swift
+++ b/Source/Utils/Extensions/UIColor+Constants.swift
@@ -13,5 +13,6 @@ extension UIColor {
     static let selectedBackgroundColor = UIColor(rgb: 0x2B303B)
 
     static let textColor               = UIColor(rgb: 0xFFFFFF)
+    static let mutedTextColor          = UIColor(rgb: 0x6B6B70)
     static let dangerTextColor         = UIColor(rgb: 0x9E3621)
 }


### PR DESCRIPTION
Also changed color of version, so it doesn't look interactable.

PS: It's not possible to go straight to push notification settings, it's private API & will get rejected in App Store review. But it's easily accessible there anyway.

![2020-02-24 15 13 24](https://user-images.githubusercontent.com/5606812/75179413-c7bb6480-5718-11ea-82bf-de5d59a061fa.gif)