### PR TITLE
Change date format to the one used in Virgil SDK

### DIFF
--- a/Source/Models/EncryptedMessage.swift
+++ b/Source/Models/EncryptedMessage.swift
@@ -31,14 +31,6 @@ public class EncryptedMessage: Codable {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .custom(DateUtils.timestampDateDecodingStrategy)
 
-
-        // If message appears to be too old, it was probably created using
-        // .deferredToDate format
-        /*guard Calendar.current.component(.year, from: message.date) > 2000 else {
-            decoder.dateDecodingStrategy = .deferredToDate
-            return try decoder.decode(EncryptedMessage.self, from: data)
-        }*/
-
         return try decoder.decode(EncryptedMessage.self, from: data)
     }
 

--- a/Source/Models/EncryptedMessage.swift
+++ b/Source/Models/EncryptedMessage.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import XMPPFrameworkSwift
+import VirgilSDK
 
 public enum EncryptedMessageError: Int, Error {
     case bodyIsNotBase64Encoded = 1
@@ -28,14 +29,22 @@ public class EncryptedMessage: Codable {
         }
 
         let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .secondsSince1970
+        decoder.dateDecodingStrategy = .custom(DateUtils.timestampDateDecodingStrategy)
+
+
+        // If message appears to be too old, it was probably created using
+        // .deferredToDate format
+        /*guard Calendar.current.component(.year, from: message.date) > 2000 else {
+            decoder.dateDecodingStrategy = .deferredToDate
+            return try decoder.decode(EncryptedMessage.self, from: data)
+        }*/
 
         return try decoder.decode(EncryptedMessage.self, from: data)
     }
 
     func export() throws -> String {
         let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .secondsSince1970
+        encoder.dateEncodingStrategy = .custom(DateUtils.timestampDateEncodingStrategy)
 
         return try encoder.encode(self).base64EncodedString()
     }

--- a/Source/Models/EncryptedMessage.swift
+++ b/Source/Models/EncryptedMessage.swift
@@ -27,12 +27,16 @@ public class EncryptedMessage: Codable {
             throw EncryptedMessageError.bodyIsNotBase64Encoded
         }
 
-        return try JSONDecoder().decode(EncryptedMessage.self, from: data)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .millisecondsSince1970
+
+        return try decoder.decode(EncryptedMessage.self, from: data)
     }
 
     func export() throws -> String {
-        let data = try JSONEncoder().encode(self)
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .millisecondsSince1970
 
-        return data.base64EncodedString()
+        return try encoder.encode(self).base64EncodedString()
     }
 }

--- a/Source/Models/EncryptedMessage.swift
+++ b/Source/Models/EncryptedMessage.swift
@@ -28,14 +28,14 @@ public class EncryptedMessage: Codable {
         }
 
         let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .millisecondsSince1970
+        decoder.dateDecodingStrategy = .secondsSince1970
 
         return try decoder.decode(EncryptedMessage.self, from: data)
     }
 
     func export() throws -> String {
         let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .millisecondsSince1970
+        encoder.dateEncodingStrategy = .secondsSince1970
 
         return try encoder.encode(self).base64EncodedString()
     }


### PR DESCRIPTION
This format is more common and easier to reproduce in other platforms. By default it's .deferredToDate, which is Apple's weird January 1st 2001 based format, which needs to be calculated manually in platforms other than iOS and macOS.